### PR TITLE
[FIX] 사용자 목록 모달 구현 재PR

### DIFF
--- a/src/apis/user/getAllUsers.ts
+++ b/src/apis/user/getAllUsers.ts
@@ -1,0 +1,24 @@
+import { GET_ALL_USER_LIST_PATH } from '@/utils/api_paths'
+import axiosInstance from '../api'
+
+interface UserResponse extends User {}
+
+interface AllUserProps {
+  offset?: number
+  limit?: number
+}
+
+// TODO: Params 추가하기
+async function getAllUsers({
+  offset,
+  limit
+}: AllUserProps): Promise<UserResponse[]> {
+  try {
+    const response = await axiosInstance.get(GET_ALL_USER_LIST_PATH)
+    return response.data
+  } catch (error) {
+    throw new Error('Error while getting All Users')
+  }
+}
+
+export default getAllUsers

--- a/src/apis/user/getOnlineUsers.ts
+++ b/src/apis/user/getOnlineUsers.ts
@@ -1,0 +1,16 @@
+import { GET_ONLINE_USER_LIST_PATH } from '@/utils/api_paths'
+import axiosInstance from '../api'
+
+interface UserResponse extends User {}
+
+// TODO: Params 추가하기
+async function getOnlineUsers(): Promise<UserResponse[]> {
+  try {
+    const response = await axiosInstance.get(GET_ONLINE_USER_LIST_PATH)
+    return response.data
+  } catch (error) {
+    throw new Error('Error while getting Online Users')
+  }
+}
+
+export default getOnlineUsers

--- a/src/pages/Home/components/bottom-navbar/index.tsx
+++ b/src/pages/Home/components/bottom-navbar/index.tsx
@@ -7,6 +7,8 @@ import UserListIcon from '@/assets/icons/userlist.svg'
 import ProfileIcon from '@/assets/icons/profile.svg'
 import ScrollTopIcon from '@/assets/icons/scrollTop.svg'
 import { useProfileStore } from '@/stores/userProfileStore'
+import { useState } from 'react'
+import Modal from '@/pages/Home/components/users-list-modal/Modal'
 
 const HomeBottomNavBarContainer = styled.div`
   ${tw`fixed left-1/2 transform -translate-x-1/2 bottom-4 flex z-10 bg-white w-56 h-12 justify-evenly rounded-full shadow-lg`}
@@ -14,37 +16,49 @@ const HomeBottomNavBarContainer = styled.div`
 
 const HomeBottomNavBar = () => {
   const { profile } = useProfileStore()
+  const [isUsersListModalOpen, setIsUsersListModalOpen] = useState(false)
+
+  const handleUsersListModal = () => {
+    setIsUsersListModalOpen((prev) => !prev)
+  }
+
   return (
-    <HomeBottomNavBarContainer>
-      <Link
-        to={`/profile/${profile?._id}`}
-        className="h-fit my-auto">
-        <img
-          className="w-5 h-5"
-          src={ProfileIcon}
-        />
-      </Link>
-      <button>
-        <img
-          className="w-7 h-7 my-auto"
-          src={UserListIcon}
-        />
-      </button>
-      <button>
-        <img
-          className="w-7 h-7 my-auto"
-          src={ScrollTopIcon}
-        />
-      </button>
-      <Link
-        to="/post-creation"
-        className="h-fit my-auto">
-        <img
-          className="w-7 h-6"
-          src={WriteIcon}
-        />
-      </Link>
-    </HomeBottomNavBarContainer>
+    <>
+      <HomeBottomNavBarContainer>
+        <Link
+          to={`/profile/${profile?._id}`}
+          className="h-fit my-auto">
+          <img
+            className="w-5 h-5"
+            src={ProfileIcon}
+          />
+        </Link>
+        <button onClick={handleUsersListModal}>
+          <img
+            className="w-7 h-7 my-auto"
+            src={UserListIcon}
+          />
+        </button>
+        <button>
+          <img
+            className="w-7 h-7 my-auto"
+            src={ScrollTopIcon}
+          />
+        </button>
+        <Link
+          to="/post-creation"
+          className="h-fit my-auto">
+          <img
+            className="w-7 h-6"
+            src={WriteIcon}
+          />
+        </Link>
+      </HomeBottomNavBarContainer>
+      <Modal
+        isOpen={isUsersListModalOpen}
+        onToggle={handleUsersListModal}
+      />
+    </>
   )
 }
 export default HomeBottomNavBar

--- a/src/pages/Home/components/bottom-navbar/index.tsx
+++ b/src/pages/Home/components/bottom-navbar/index.tsx
@@ -8,7 +8,7 @@ import ProfileIcon from '@/assets/icons/profile.svg'
 import ScrollTopIcon from '@/assets/icons/scrollTop.svg'
 import { useProfileStore } from '@/stores/userProfileStore'
 import { useState } from 'react'
-import Modal from '@/pages/Home/components/users-list-modal/Modal'
+import Modal from '@/pages/home/components/users-list-modal/Modal'
 
 const HomeBottomNavBarContainer = styled.div`
   ${tw`fixed left-1/2 transform -translate-x-1/2 bottom-4 flex z-10 bg-white w-56 h-12 justify-evenly rounded-full shadow-lg`}

--- a/src/pages/Home/components/bottom-navbar/index.tsx
+++ b/src/pages/Home/components/bottom-navbar/index.tsx
@@ -1,14 +1,13 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import tw from 'twin.macro'
-
 import WriteIcon from '@/assets/icons/write.svg'
 import UserListIcon from '@/assets/icons/userlist.svg'
 import ProfileIcon from '@/assets/icons/profile.svg'
 import ScrollTopIcon from '@/assets/icons/scrollTop.svg'
-import { useProfileStore } from '@/stores/userProfileStore'
-import { useState } from 'react'
 import Modal from '@/pages/home/components/users-list-modal/Modal'
+import { useProfileStore } from '@/stores/userProfileStore'
 
 const HomeBottomNavBarContainer = styled.div`
   ${tw`fixed left-1/2 transform -translate-x-1/2 bottom-4 flex z-10 bg-white w-56 h-12 justify-evenly rounded-full shadow-lg`}

--- a/src/pages/Home/components/users-list-modal/Modal.tsx
+++ b/src/pages/Home/components/users-list-modal/Modal.tsx
@@ -1,6 +1,9 @@
 import tw, { styled } from 'twin.macro'
 import TabItem from './TabItem'
 import TabContent from './TabContent'
+import { useEffect, useState } from 'react'
+import getAllUsers from '@/apis/user/getAllUsers'
+import getOnlineUsers from '@/apis/user/getOnlineUsers'
 
 interface UsersListProps {
   isOpen: boolean
@@ -21,6 +24,23 @@ const ModalBackdrop = styled.form`
 `
 
 const Modal = ({ isOpen, onToggle }: UsersListProps) => {
+  const [allUsers, setAllUsers] = useState<User[]>([])
+  const [onlineUsers, setOnlineUsers] = useState<User[]>([])
+
+  useEffect(() => {
+    const fetchAllUsers = async () => {
+      const data: User[] = await getAllUsers({})
+      setAllUsers(data)
+    }
+
+    const fetchOnlineUsers = async () => {
+      const data: User[] = await getOnlineUsers()
+      setOnlineUsers(data)
+    }
+    fetchAllUsers()
+    fetchOnlineUsers()
+  }, [])
+
   return (
     <ModalContainer
       id="modal"
@@ -31,9 +51,9 @@ const Modal = ({ isOpen, onToggle }: UsersListProps) => {
             title={'모든 사용자'}
             checked
           />
-          <TabContent />
+          <TabContent users={allUsers} />
           <TabItem title={'접속 중인 사용자'} />
-          <TabContent />
+          <TabContent users={onlineUsers} />
         </TabList>
       </div>
       <ModalBackdrop method="dialog">

--- a/src/pages/Home/components/users-list-modal/Modal.tsx
+++ b/src/pages/Home/components/users-list-modal/Modal.tsx
@@ -1,0 +1,46 @@
+import tw, { styled } from 'twin.macro'
+import TabItem from './TabItem'
+import TabContent from './TabContent'
+
+interface UsersListProps {
+  isOpen: boolean
+  onToggle: () => void
+}
+
+const ModalContainer = styled.div(({ isOpen }) => [
+  tw`modal modal-bottom`,
+  isOpen && tw`modal-open`
+])
+
+const TabList = styled.div`
+  ${tw`tabs tabs-lifted tabs-lg`}
+`
+
+const ModalBackdrop = styled.form`
+  ${tw`modal-backdrop bg-[#000]/20`}
+`
+
+const Modal = ({ isOpen, onToggle }: UsersListProps) => {
+  return (
+    <ModalContainer
+      id="modal"
+      isOpen={isOpen}>
+      <div className="modal-box w-full h-96 p-0">
+        <TabList role="tablist">
+          <TabItem
+            title={'모든 사용자'}
+            checked
+          />
+          <TabContent />
+          <TabItem title={'접속 중인 사용자'} />
+          <TabContent />
+        </TabList>
+      </div>
+      <ModalBackdrop method="dialog">
+        <button onClick={onToggle}>close</button>
+      </ModalBackdrop>
+    </ModalContainer>
+  )
+}
+
+export default Modal

--- a/src/pages/Home/components/users-list-modal/Modal.tsx
+++ b/src/pages/Home/components/users-list-modal/Modal.tsx
@@ -10,7 +10,11 @@ interface UsersListProps {
   onToggle: () => void
 }
 
-const ModalContainer = styled.div(({ isOpen }) => [
+interface ModalContainerProps {
+  isOpen: boolean
+}
+
+const ModalContainer = styled.div<ModalContainerProps>(({ isOpen }) => [
   tw`modal modal-bottom`,
   isOpen && tw`modal-open`
 ])

--- a/src/pages/Home/components/users-list-modal/Modal.tsx
+++ b/src/pages/Home/components/users-list-modal/Modal.tsx
@@ -1,7 +1,7 @@
+import { useEffect, useState } from 'react'
 import tw, { styled } from 'twin.macro'
 import TabItem from './TabItem'
 import TabContent from './TabContent'
-import { useEffect, useState } from 'react'
 import getAllUsers from '@/apis/user/getAllUsers'
 import getOnlineUsers from '@/apis/user/getOnlineUsers'
 

--- a/src/pages/Home/components/users-list-modal/ProfileCard.tsx
+++ b/src/pages/Home/components/users-list-modal/ProfileCard.tsx
@@ -1,0 +1,41 @@
+import NoProfileThumbnailIcon from '@/pages/search/components/NoProfileThumbnailIcon'
+import { Link } from 'react-router-dom'
+import tw, { styled } from 'twin.macro'
+
+interface ProfileCardProps {
+  id: string
+  fullName: string
+  profileImage?: string
+}
+
+const Container = styled.div`
+  ${tw`flex flex-col items-center justify-center`}
+`
+
+const ProfileImageWrapper = styled.div`
+  ${tw`relative overflow-hidden rounded-full w-20 h-20`}
+`
+
+const ProfileCard = ({ id, fullName, profileImage }: ProfileCardProps) => {
+  return (
+    <Link to={`/profile/${id}`} className="w-full h-full">
+    <Container>
+      <ProfileImageWrapper>
+        {profileImage && (
+          <img
+            src={profileImage}
+            alt="프로필 이미지"
+            className="w-full h-full rounded-full object-cover z-10 bg-white"
+          />
+        )}
+        {!profileImage && (
+          <NoProfileThumbnailIcon className="w-full h-full rounded-full text-[#ddd] bg-[#fff]" />
+        )}
+      </ProfileImageWrapper>
+      <div className='text-xs'>{fullName}</div>
+    </Container>
+    </Link>
+  )
+}
+
+export default ProfileCard

--- a/src/pages/Home/components/users-list-modal/ProfileCard.tsx
+++ b/src/pages/Home/components/users-list-modal/ProfileCard.tsx
@@ -1,6 +1,6 @@
-import NoProfileThumbnailIcon from '@/pages/search/components/NoProfileThumbnailIcon'
 import { Link } from 'react-router-dom'
 import tw, { styled } from 'twin.macro'
+import NoProfileThumbnailIcon from '@/pages/search/components/NoProfileThumbnailIcon'
 
 interface ProfileCardProps {
   id: string
@@ -18,22 +18,24 @@ const ProfileImageWrapper = styled.div`
 
 const ProfileCard = ({ id, fullName, profileImage }: ProfileCardProps) => {
   return (
-    <Link to={`/profile/${id}`} className="w-full h-full">
-    <Container>
-      <ProfileImageWrapper>
-        {profileImage && (
-          <img
-            src={profileImage}
-            alt="프로필 이미지"
-            className="w-full h-full rounded-full object-cover z-10 bg-white"
-          />
-        )}
-        {!profileImage && (
-          <NoProfileThumbnailIcon className="w-full h-full rounded-full text-[#ddd] bg-[#fff]" />
-        )}
-      </ProfileImageWrapper>
-      <div className='text-xs'>{fullName}</div>
-    </Container>
+    <Link
+      to={`/profile/${id}`}
+      className="w-full h-full">
+      <Container>
+        <ProfileImageWrapper>
+          {profileImage && (
+            <img
+              src={profileImage}
+              alt="프로필 이미지"
+              className="w-full h-full rounded-full object-cover z-10 bg-white"
+            />
+          )}
+          {!profileImage && (
+            <NoProfileThumbnailIcon className="w-full h-full rounded-full text-[#ddd] bg-[#fff]" />
+          )}
+        </ProfileImageWrapper>
+        <div className="text-xs">{fullName}</div>
+      </Container>
     </Link>
   )
 }

--- a/src/pages/Home/components/users-list-modal/TabContent.tsx
+++ b/src/pages/Home/components/users-list-modal/TabContent.tsx
@@ -1,9 +1,27 @@
-const TabContent = () => {
+import ProfileCard from './ProfileCard'
+
+interface TabContentProps {
+  users: User[]
+}
+const TabContent = ({ users }: TabContentProps) => {
   return (
     <div
       role="tabpanel"
-      className="tab-content bg-base-100 border-base-300 rounded-box p-6">
-      
+      className="tab-content bg-base-100 border-base-300 rounded-box px-2 py-3 w-full min-w-0">
+      {users.length > 0 && (
+        <div className="w-full h-full grid grid-flow-col-dense grid-cols-4 grid-rows-10 gap-3">
+          {users.map(({ _id, fullName, image }) => (
+            <ProfileCard
+              id={_id}
+              fullName={fullName}
+              profileImage={image}
+            />
+          ))}
+        </div>
+      )}
+      {users.length === 0 && (
+        <div className="px-2 text-[#949494]">사용자가 없습니다.</div>
+      )}
     </div>
   )
 }

--- a/src/pages/Home/components/users-list-modal/TabContent.tsx
+++ b/src/pages/Home/components/users-list-modal/TabContent.tsx
@@ -1,0 +1,11 @@
+const TabContent = () => {
+  return (
+    <div
+      role="tabpanel"
+      className="tab-content bg-base-100 border-base-300 rounded-box p-6">
+      
+    </div>
+  )
+}
+
+export default TabContent

--- a/src/pages/Home/components/users-list-modal/TabItem.tsx
+++ b/src/pages/Home/components/users-list-modal/TabItem.tsx
@@ -1,0 +1,19 @@
+interface TabItemProps {
+  title: string
+  checked?: boolean
+}
+
+const TabItem = ({ title, checked }: TabItemProps) => {
+  return (
+    <input
+      type="radio"
+      name="my_tabs_2"
+      role="tab"
+      className="tab"
+      aria-label={title}
+      checked={checked}
+    />
+  )
+}
+
+export default TabItem

--- a/src/pages/Home/components/users-list-modal/TabItem.tsx
+++ b/src/pages/Home/components/users-list-modal/TabItem.tsx
@@ -9,7 +9,7 @@ const TabItem = ({ title, checked }: TabItemProps) => {
       type="radio"
       name="my_tabs_2"
       role="tab"
-      className="tab"
+      className="tab font-bold"
       aria-label={title}
       readOnly
       checked={checked}

--- a/src/pages/Home/components/users-list-modal/TabItem.tsx
+++ b/src/pages/Home/components/users-list-modal/TabItem.tsx
@@ -11,6 +11,7 @@ const TabItem = ({ title, checked }: TabItemProps) => {
       role="tab"
       className="tab"
       aria-label={title}
+      readOnly
       checked={checked}
     />
   )

--- a/src/utils/api_paths.ts
+++ b/src/utils/api_paths.ts
@@ -1,7 +1,6 @@
 /* 어드민 */
 export const CREATE_CHANNEL_BY_ADMIN_PATH = '/channels/create'
 
-
 /* 인증 */
 export const LOGIN_PATH = '/login'
 export const SIGNUP_PATH = '/signup'
@@ -9,6 +8,7 @@ export const LOGOUT_PATH = '/logout'
 export const AUTH_CHECK = '/auth-user'
 /* 사용자 */
 export const GET_ALL_USER_LIST_PATH = '/users/get-users'
+export const GET_ONLINE_USER_LIST_PATH = '/users/online-users'
 export const GET_USER_PROFILE_PATH = '/users'
 export const UPDATE_PROFILE_IMAGE_PATH = '/users/upload-photo'
 export const UPDATE_COVER_IMAGE_PATH = '/users/upload-photo'


### PR DESCRIPTION
## 관련 이슈
- 이슈 링크: https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/issues/35

<br />

## 작업 내용
- 네비게이션 바에서 사용자 목록 아이콘 클릭 시, 모달이 나타납니다.
- 사용자 아이템을 클릭 시, 해당 사용자의 프로필 페이지로 이동합니다.

https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/assets/101445377/7098204e-b77f-4845-9c2f-b0389e9c7f49

<br />

## 특이 사항
- 팔로우 기능이 머지되지 않은 develop 브랜치를 base로 작업했습니다. 그래서 이대로 PR후, 머지해도 될지,,,? 잘 모르겠습니다.
 
<br />

## 리뷰 요구사항 (선택)
- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요?
- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요?
- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?