### PR TITLE
[FIX] 팔로우, 팔로위 취소 기능 구현 Re-PR

### DIFF
--- a/src/pages/profile/components/profile-edit-drawer/ProfileInput.tsx
+++ b/src/pages/profile/components/profile-edit-drawer/ProfileInput.tsx
@@ -8,6 +8,7 @@ interface InputProps {
   placeholder: string
   type: string
   onChangeInput: (e: React.ChangeEvent<HTMLInputElement>) => void
+  error?: string
 }
 
 const Input = styled.input`
@@ -24,11 +25,15 @@ const ProfileInput = ({
   value,
   placeholder,
   type,
-  onChangeInput
+  onChangeInput,
+  error
 }: InputProps) => {
   return (
     <div>
-      <Label>{labelName}</Label>
+      <div className="flex justify-between items-center">
+        <Label>{labelName}</Label>
+        <p className="text-xs text-[crimson] px-1 py-2 w-fit">{error}</p>
+      </div>
       <Input
         type={type}
         name={name}

--- a/src/pages/profile/components/profile-edit-drawer/ProfileNameForm.tsx
+++ b/src/pages/profile/components/profile-edit-drawer/ProfileNameForm.tsx
@@ -3,8 +3,15 @@ import tw, { styled } from 'twin.macro'
 import ProfileInput from './ProfileInput'
 
 import updateName from '@/apis/profile/updateName'
-import { useProfileStore } from '@/stores/userProfileStore'
 import useForm from '@/hooks/useForm'
+import { useProfileStore } from '@/stores/userProfileStore'
+
+const ERRORS = {
+  EMPTY_FULLNAME: '실명을 입력해주세요.',
+  TOO_LONG_FULLNAME: '실명은 6자 이내로 입력해주세요.',
+  EMPTY_USERNAME: '사용자 명을 입력해주세요.',
+  TOO_LONG_USERNAME: '사용자 명은 8자 이내로 입력해주세요.'
+}
 
 const Form = styled.form`
   ${tw`w-full flex flex-col`}
@@ -40,15 +47,15 @@ const ProfileNameForm = () => {
       const errors = {} as Record<string, string>
 
       if (values.fullName.length === 0) {
-        errors.fullName = '실명을 입력해주세요.'
+        errors.fullName = ERRORS.EMPTY_FULLNAME
       } else if (values.fullName.length > 6) {
-        errors.fullName = '실명은 6자 이내로 입력해주세요.'
+        errors.fullName = ERRORS.TOO_LONG_FULLNAME
       }
 
       if (values.username.length === 0) {
-        errors.username = '사용자 명을 입력해주세요.'
+        errors.username = ERRORS.EMPTY_USERNAME
       } else if (values.username.length > 8) {
-        errors.username = '사용자 명은 8자 이내로 입력해주세요.'
+        errors.username = ERRORS.TOO_LONG_USERNAME
       }
 
       return errors

--- a/src/pages/profile/components/profile-edit-drawer/ProfileNameForm.tsx
+++ b/src/pages/profile/components/profile-edit-drawer/ProfileNameForm.tsx
@@ -26,7 +26,7 @@ const sleep = () => {
 
 const ProfileNameForm = () => {
   const { profile, setProfile } = useProfileStore()
-  const { values, isLoading, handleChange, handleSubmit } = useForm({
+  const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValue: {
       fullName: profile?.fullName || '',
       username: profile?.username || ''
@@ -35,6 +35,23 @@ const ProfileNameForm = () => {
       await sleep()
       const data = await updateName(values)
       setProfile(data)
+    },
+    validate: (values) => {
+      const errors = {} as Record<string, string>
+
+      if (values.fullName.length === 0) {
+        errors.fullName = '실명을 입력해주세요.'
+      } else if (values.fullName.length > 6) {
+        errors.fullName = '실명은 6자 이내로 입력해주세요.'
+      }
+
+      if (values.username.length === 0) {
+        errors.username = '사용자 명을 입력해주세요.'
+      } else if (values.username.length > 8) {
+        errors.username = '사용자 명은 8자 이내로 입력해주세요.'
+      }
+
+      return errors
     }
   })
 
@@ -47,6 +64,7 @@ const ProfileNameForm = () => {
         placeholder="사용자 명을 입력해주세요."
         type="text"
         onChangeInput={handleChange}
+        error={errors.username}
       />
       <ProfileInput
         labelName="실명"
@@ -55,6 +73,7 @@ const ProfileNameForm = () => {
         placeholder="실명을 입력해주세요."
         type="text"
         onChangeInput={handleChange}
+        error={errors.fullName}
       />
       <SubmitButton type="submit">
         {isLoading ? '변경 중' : '변경'}

--- a/src/pages/profile/components/profile-edit-drawer/ProfilePasswordForm.tsx
+++ b/src/pages/profile/components/profile-edit-drawer/ProfilePasswordForm.tsx
@@ -4,6 +4,7 @@ import ProfileInput from './ProfileInput'
 
 import updatePassword from '@/apis/profile/updatePassword'
 import useForm from '@/hooks/useForm'
+import isPasswordValid from '@/utils/passwordValidator'
 
 const Form = styled.form`
   ${tw`w-full flex flex-col`}
@@ -20,8 +21,8 @@ const SubmitButton = styled.button`
 `
 
 const sleep = () => {
-  return new Promise((resolve) => setTimeout(resolve, 1000));
-};
+  return new Promise((resolve) => setTimeout(resolve, 1000))
+}
 
 const ProfilePasswordForm = () => {
   const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
@@ -35,6 +36,19 @@ const ProfilePasswordForm = () => {
         password: values.password
       })
     },
+    validate: (values) => {
+      const errors = {} as Record<string, string>
+      if (!isPasswordValid(values.password)) {
+        errors.password =
+          '비밀번호는 8자 이상, 특수문자, 대문자, 숫자를 포함해야 합니다.'
+      }
+
+      if (values.password !== values.confirmPassword) {
+        errors.confirmPassword = '비밀번호가 일치하지 않습니다.'
+      }
+
+      return errors
+    }
   })
 
   return (
@@ -46,6 +60,7 @@ const ProfilePasswordForm = () => {
         placeholder="새로운 비밀번호를 입력해주세요."
         type="password"
         onChangeInput={handleChange}
+        error={errors.password}
       />
       <ProfileInput
         labelName="비밀번호 확인"
@@ -54,9 +69,12 @@ const ProfilePasswordForm = () => {
         placeholder="비밀번호를 다시 입력해주세요."
         type="password"
         onChangeInput={handleChange}
+        error={errors.confirmPassword}
       />
       <span className="text-xs text-[crimson] px-1 py-2 w-fit">
-        {values.password.length === 0 && values.confirmPassword.length !== 0 && '비밀번호를 입력해주세요.'}
+        {values.password.length === 0 &&
+          values.confirmPassword.length !== 0 &&
+          '비밀번호를 입력해주세요.'}
         {values.password.length !== 0 &&
           values.password !== values.confirmPassword &&
           '비밀번호가 일치하지 않습니다.'}

--- a/src/pages/profile/components/profile/UserProfileInfo.tsx
+++ b/src/pages/profile/components/profile/UserProfileInfo.tsx
@@ -65,14 +65,11 @@ const UserProfileInfo = ({
         <ChatButton>
           <ChatIcon className="w-full h-full" />
         </ChatButton>
-        {!isMyProfile && isFollowed && (
+        {!isMyProfile && (
           <FollowButton
-            isFilled
+            isFilled={isFollowed}
             onClick={onClickFollowButton}
           />
-        )}
-        {!isMyProfile && !isFollowed && (
-          <FollowButton onClick={onClickFollowButton} />
         )}
       </ButtonContainer>
     </UserProfileInfoWrapper>

--- a/src/pages/profile/components/profile/UserProfileInfo.tsx
+++ b/src/pages/profile/components/profile/UserProfileInfo.tsx
@@ -15,6 +15,10 @@ interface UserProfileInfoProps {
   onClickFollowButton: () => void
 }
 
+interface OnlineIndicatorProps {
+  isOnline?: boolean
+}
+
 const UserProfileInfoWrapper = styled.div`
   ${tw`flex justify-between gap-3`}
 `
@@ -27,7 +31,7 @@ const UserNameWrapper = styled.div`
   ${tw`flex items-center gap-2`}
 `
 
-const OnlineIndicator = styled.div(({ isOnline }) => [
+const OnlineIndicator = styled.div<OnlineIndicatorProps>(({ isOnline }) => [
   tw`w-2 h-2 rounded-full bg-[crimson] self-end mb-1`,
   isOnline && tw`bg-[limegreen]`
 ])

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -6,10 +6,12 @@ import Header from './components/Header'
 import PostList from './components/profile/PostList'
 import Drawer from './components/profile-edit-drawer/Drawer'
 import EditIcon from './components/EditIcon'
-import getProfile from '@/apis/profile/profile'
 import ProfileImage from './components/ProfileImage'
 import CoverImage from './components/CoverImage'
 import { useProfileStore } from '@/stores/userProfileStore'
+import getProfile from '@/apis/profile/profile'
+import unfollow from '@/apis/follow/unfollow'
+import follow from '@/apis/follow/follow'
 
 const ProfileContainer = styled.main`
   ${tw`w-full h-screen relative`}
@@ -41,9 +43,9 @@ const Profile = () => {
   const { id } = useParams()
   const { profile, setProfile } = useProfileStore()
   const [currentProfile, setCurrentProfile] = useState<User>()
-  const isMyProfile = id === profile?._id
   const [isFollowed, setIsFollowed] = useState<boolean>(false)
   const [isOpen, setIsOpen] = useState<boolean>(false)
+  const isMyProfile = id === profile?._id
 
   const handleToggleDrawer = () => {
     setIsOpen(!isOpen)
@@ -69,10 +71,24 @@ const Profile = () => {
     checkIsFollowedUser()
   }, [profile?.following, id])
 
-  const handleClickFollowButton = () => {
+  const handleClickFollowButton = async () => {
+    let data = null
+
+    if (!isFollowed) {
+      data = await follow({ userId: id as string })
+    } else {
+      const filteredFollowing = profile?.following.find(
+        (item) => item.user === id
+      )
+      data = await unfollow({ id: filteredFollowing?._id as string }) // 팔로우 모델에서 _id필드를 id로 넣어야 함
+    }
+
+    const updatedProfile = await getProfile(data.follower)
+    setProfile(updatedProfile)
+
     setIsFollowed((prev) => !prev)
   }
-
+  
   return (
     <Drawer
       isOpen={isOpen}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,16 +1,15 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
 import tw, { styled } from 'twin.macro'
-
 import UserProfileInfo from './components/profile/UserProfileInfo'
 import Header from './components/Header'
 import PostList from './components/profile/PostList'
 import Drawer from './components/profile-edit-drawer/Drawer'
 import EditIcon from './components/EditIcon'
 import getProfile from '@/apis/profile/profile'
-import { useProfileStore } from '@/stores/userProfileStore'
 import ProfileImage from './components/ProfileImage'
 import CoverImage from './components/CoverImage'
-import { useParams } from 'react-router-dom'
+import { useProfileStore } from '@/stores/userProfileStore'
 
 const ProfileContainer = styled.main`
   ${tw`w-full h-screen relative`}


### PR DESCRIPTION
## 관련 이슈
- 이슈 링크: https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/issues/30

<br />

## 작업 내용
- 팔로우, 팔로우 취소 기능을 구현했습니다.
  - 팔로우 버튼을 눌러서 동작을 수행할 수 있습니다.


<br />

## 특이 사항
- 팔로우 요청 또는 취소 시, 낙관적 업데이트는 적용하지 않았습니다.
  - 추후 react-query를 사용하게 된다면, 그때 적용해도 될 것 같아 보류했습니다. 이에 대해서 **많은 의견 부탁드립니다!**
- **_사용자 정보 편집 기능에서 유효성 검사를 수행하는 코드를 따로 세분화해서 PR한다면, 머지 시 번거로울 것 같아서 현 PR에 작업했습니다. 저희가 정한 룰에 위배된다면 말씀 부탁드립니다!_**
<br />

## 리뷰 요구사항 (선택)
- 리뷰 중점 사항: 코드 컨벤션에 어긋나는 부분이 있나요?
- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요?
- 논의가 필요한 부분
  - **팔로잉, 팔로워를 눌렀을 때 사용자 목록이 나타나는 디자인을 추가하는 건 어떨까요?**
  - API 요청 시 **토큰을 사용하는 함수**가 꽤 있는 것 같습니다. 이를 **하나의 상수로 불러와서 사용**하는 건 어떨까요? 너무 과할까요? 
![스크린샷 2024-01-08 11 42 27](https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/assets/101445377/54c19871-e3bf-47c6-9d61-964665b4c4b4)


