### PR TITLE
댓글 삭제 기능 수정, 댓글 스타일 깨짐 수정

### DIFF
--- a/src/apis/commnents.ts
+++ b/src/apis/commnents.ts
@@ -1,12 +1,16 @@
 import axiosInstance from './api'
 import { CREATE_COMMENT_PATH, DELETE_COMMENT_PATH } from '@/utils/api_paths'
 
-const config = {
-  headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TOKEN}`
-  }
+const getToken = () => {
+  const token = localStorage.getItem('token')
+  return JSON.parse(token as string)
 }
 
+const config = {
+  headers: {
+    Authorization: `Bearer ${getToken()}`
+  }
+}
 export async function createComment(
   comment: string,
   postId: string

--- a/src/apis/notifications.ts
+++ b/src/apis/notifications.ts
@@ -5,9 +5,14 @@ import {
   UPDATE_NOTIFICATIONS_PATH
 } from '@/utils/api_paths'
 
+const getToken = () => {
+  const token = localStorage.getItem('token')
+  return JSON.parse(token as string)
+}
+
 const config = {
   headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TOKEN}`
+    Authorization: `Bearer ${getToken()}`
   }
 }
 

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -1,34 +1,41 @@
 import { useState } from 'react'
+
+import { useProfileStore } from '@/stores/userProfileStore'
+
 import { createComment } from '@/apis/commnents'
 import { createNotification } from '@/apis/notifications'
 import commentUploadIcon from '@/assets/icons/commentUpload.svg'
 
 type CommentFormProps = {
+  postUserId: string
   postId: string
   onCommentAdded: () => void
   setCommentNumber: React.Dispatch<React.SetStateAction<number>>
 }
 
 const CommentForm = ({
+  postUserId,
   postId,
   onCommentAdded,
   setCommentNumber
 }: CommentFormProps) => {
+  const { profile } = useProfileStore()
+
   const [comment, setComment] = useState('')
 
   const handleUploadIconClick = async () => {
     try {
       const response = await createComment(comment, postId)
+      console.log(response)
       setComment('')
       setCommentNumber((prev) => prev + 1)
 
       // TODO: 사용자가 댓글 달았을 때는 알림 생성 제외 구현하기
-      await createNotification(
-        'COMMENT',
-        response._id,
-        response.author._id,
-        postId
-      )
+      console.log(response.author._id, profile?._id)
+      if (postUserId !== profile?._id) {
+        console.log('!!')
+        await createNotification('COMMENT', response._id, postUserId, postId)
+      }
 
       if (onCommentAdded) {
         onCommentAdded()

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -26,14 +26,10 @@ const CommentForm = ({
   const handleUploadIconClick = async () => {
     try {
       const response = await createComment(comment, postId)
-      console.log(response)
       setComment('')
       setCommentNumber((prev) => prev + 1)
 
-      // TODO: 사용자가 댓글 달았을 때는 알림 생성 제외 구현하기
-      console.log(response.author._id, profile?._id)
       if (postUserId !== profile?._id) {
-        console.log('!!')
         await createNotification('COMMENT', response._id, postUserId, postId)
       }
 

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -24,7 +24,7 @@ const CommentItem = ({ comment, onDelete }: CommentItemProps) => {
           <div className="text-sm text-gray-500">{formatDate(createdAt)}</div>
         </div>
         <div className="flex justify-between items-center min-w-0">
-          <div className="py-1">{commentText}</div>
+          <div className="py-1 flex-grow overflow-hidden">{commentText}</div>
           {canDeleteComment() && (
             <img
               className="cursor-pointer ml-4"

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -17,10 +17,10 @@ const CommentItem = ({ comment, onDelete }: CommentItemProps) => {
           <div className="font-medium">{author.fullName}</div>
           <div className="text-sm text-gray-500">{formatDate(createdAt)}</div>
         </div>
-        <div className="flex justify-between items-center">
-          <div className="py-2">{commentText}</div>
+        <div className="flex justify-between items-center min-w-0">
+          <div className="py-1">{commentText}</div>
           <img
-            className="cursor-pointer"
+            className="cursor-pointer ml-4"
             src={commentDeleteIcon}
             alt="댓글 삭제 아이콘"
             onClick={() => onDelete(_id)}

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,3 +1,4 @@
+import { useProfileStore } from '@/stores/userProfileStore'
 import { CommentProps } from '@/components/comments/CommentList'
 import commentDeleteIcon from '@/assets/icons/commentDelete.svg'
 import formatDate from '@/utils/formatDate'
@@ -9,6 +10,11 @@ interface CommentItemProps {
 
 const CommentItem = ({ comment, onDelete }: CommentItemProps) => {
   const { _id, author, createdAt, comment: commentText } = comment
+  const { profile } = useProfileStore()
+
+  const canDeleteComment = () => {
+    return profile && profile._id === author._id
+  }
 
   return (
     <li className="mb-4 mx-8">
@@ -19,12 +25,14 @@ const CommentItem = ({ comment, onDelete }: CommentItemProps) => {
         </div>
         <div className="flex justify-between items-center min-w-0">
           <div className="py-1">{commentText}</div>
-          <img
-            className="cursor-pointer ml-4"
-            src={commentDeleteIcon}
-            alt="댓글 삭제 아이콘"
-            onClick={() => onDelete(_id)}
-          />
+          {canDeleteComment() && (
+            <img
+              className="cursor-pointer ml-4"
+              src={commentDeleteIcon}
+              alt="댓글 삭제 아이콘"
+              onClick={() => onDelete(_id)}
+            />
+          )}
         </div>
       </div>
     </li>

--- a/src/components/comments/index.tsx
+++ b/src/components/comments/index.tsx
@@ -8,11 +8,12 @@ import CommentList from './CommentList'
 import { getPostDetail } from '@/apis/postApis'
 
 type CommentsProps = {
+  postUserId: string
   postId: string
   setCommentNumber: React.Dispatch<React.SetStateAction<number>>
 }
 
-const Comments = ({ postId, setCommentNumber }: CommentsProps) => {
+const Comments = ({ postUserId, postId, setCommentNumber }: CommentsProps) => {
   const [comments, setComments] = useState<Comment[]>([])
 
   const fetchCommentsData = async (postId: string) => {
@@ -35,6 +36,7 @@ const Comments = ({ postId, setCommentNumber }: CommentsProps) => {
   return (
     <div>
       <CommentForm
+        postUserId={postUserId}
         postId={postId}
         onCommentAdded={handleCommentAdded}
         setCommentNumber={setCommentNumber}

--- a/src/pages/post-detail/compoents/PostBody.tsx
+++ b/src/pages/post-detail/compoents/PostBody.tsx
@@ -8,6 +8,7 @@ import BookMarkIcon from '@/assets/icons/bookmark.svg'
 
 type PostBodyType = {
   body: string
+  postUserId: string
   likeNum: number
   commentNum: number
   postId: string
@@ -25,7 +26,13 @@ const PostBottomNavWrapper = styled.div`
   ${tw`flex justify-between mt-6`}
 `
 
-const PostBody = ({ body, likeNum, commentNum, postId }: PostBodyType) => {
+const PostBody = ({
+  body,
+  postUserId,
+  likeNum,
+  commentNum,
+  postId
+}: PostBodyType) => {
   const [commentNumber, setCommentNumber] = useState<number>(commentNum)
   const [showComments, setShowComments] = useState(false)
 
@@ -69,6 +76,7 @@ const PostBody = ({ body, likeNum, commentNum, postId }: PostBodyType) => {
       </PostBottomNavWrapper>
       {showComments && (
         <Comments
+          postUserId={postUserId}
           postId={postId}
           setCommentNumber={setCommentNumber}
         />

--- a/src/pages/post-detail/index.tsx
+++ b/src/pages/post-detail/index.tsx
@@ -34,6 +34,7 @@ const PostDetail = () => {
           <hr className="w-4/5 mx-auto my-8 px-2" />
           <PostBody
             body={JSON.parse(postDetails.title).body}
+            userId={postDetails.author._id}
             likeNum={postDetails.likes.length}
             commentNum={postDetails.comments.length}
             postId={postDetails._id}

--- a/src/pages/post-detail/index.tsx
+++ b/src/pages/post-detail/index.tsx
@@ -34,7 +34,7 @@ const PostDetail = () => {
           <hr className="w-4/5 mx-auto my-8 px-2" />
           <PostBody
             body={JSON.parse(postDetails.title).body}
-            userId={postDetails.author._id}
+            postUserId={postDetails.author._id}
             likeNum={postDetails.likes.length}
             commentNum={postDetails.comments.length}
             postId={postDetails._id}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import tw, { styled } from 'twin.macro'
+
 import UserProfileInfo from './components/profile/UserProfileInfo'
 import Header from './components/Header'
 import PostList from './components/profile/PostList'
@@ -8,10 +9,13 @@ import Drawer from './components/profile-edit-drawer/Drawer'
 import EditIcon from './components/EditIcon'
 import ProfileImage from './components/ProfileImage'
 import CoverImage from './components/CoverImage'
+
 import { useProfileStore } from '@/stores/userProfileStore'
+
 import getProfile from '@/apis/profile/profile'
 import unfollow from '@/apis/follow/unfollow'
 import follow from '@/apis/follow/follow'
+import { createNotification } from '@/apis/notifications'
 
 const ProfileContainer = styled.main`
   ${tw`w-full h-screen relative`}
@@ -76,6 +80,10 @@ const Profile = () => {
 
     if (!isFollowed) {
       data = await follow({ userId: id as string })
+
+      if (profile) {
+        await createNotification('FOLLOW', data._id, data.user, null)
+      }
     } else {
       const filteredFollowing = profile?.following.find(
         (item) => item.user === id
@@ -88,7 +96,7 @@ const Profile = () => {
 
     setIsFollowed((prev) => !prev)
   }
-  
+
   return (
     <Drawer
       isOpen={isOpen}


### PR DESCRIPTION
## 관련 이슈
- 이슈 링크: X

<br />

## 작업 내용
- 자신의 댓글만 삭제 아이콘이 보이고, 삭제 가능하도록 수정
  - 로그인 안 한 상태
    <img width="460" alt="스크린샷 2024-01-12 오전 12 41 28" src="https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/assets/100656920/fbb610b5-c371-4a91-a83c-3806120ecec7">
  - 김윤경 계정으로 로그인 한 상태
    <img width="423" alt="스크린샷 2024-01-12 오전 12 41 46" src="https://github.com/prgrms-fe-devcourse/FEDC5_Bakers101_changyu/assets/100656920/244532bb-7405-4c27-a177-283084baddff">

- 댓글 길이가 길면 스타일이 깨지는 문제 수정

<br />

## 특이 사항

<br />

## 리뷰 요구사항 (선택)
- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요?
- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요?
- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?

